### PR TITLE
src, include: robotics: moved common part to shared_type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,7 @@ endif()
 add_subdirectory(src)
 
 set(GENERIC_MODULES common digital_filter polynomial)
-set(ROBOTICS_MODULES astar dijikstra)
+set(ROBOTICS_MODULES astar dijikstra shared_type)
 
 add_library(algorithm INTERFACE)
 target_link_libraries(algorithm INTERFACE ${GENERIC_MODULES} ${ROBOTICS_MODULES})

--- a/include/algorithm/robotics/astar/astar.hpp
+++ b/include/algorithm/robotics/astar/astar.hpp
@@ -14,26 +14,10 @@
 #include <limits>
 #include <vector>
 
+#include "algorithm/robotics/shared_type/data_type.hpp"
+#include "algorithm/robotics/shared_type/motion_constraint.hpp"
+
 namespace pllee4::graph {
-
-/**
- * @brief Coordinate
- *
- */
-struct Coordinate {
-  int x;
-  int y;
-  bool operator==(const Coordinate &other) const {
-    return (x == other.x && y == other.y);
-  }
-};
-
-struct MotionConstraint {
-  std::vector<int> dx;
-  std::vector<int> dy;
-  size_t size() const { return dx.size(); }
-};
-
 class AStar {
  public:
   /**

--- a/include/algorithm/robotics/dijikstra/dijikstra.hpp
+++ b/include/algorithm/robotics/dijikstra/dijikstra.hpp
@@ -14,38 +14,14 @@
 #include <limits>
 #include <vector>
 
+#include "algorithm/robotics/shared_type/data_type.hpp"
+#include "algorithm/robotics/shared_type/motion_constraint.hpp"
+
 namespace pllee4::graph {
-
-/**
- * @brief Coordinate
- *
- */
-struct Coordinate {
-  int x;
-  int y;
-  bool operator==(const Coordinate& other) const {
-    return (x == other.x && y == other.y);
-  }
-};
-
 /**
  * @brief
  *
  */
-struct Cell {
-  Coordinate parent_coordinate;
-  float cost{std::numeric_limits<float>::max()};
-  bool occupied{false};
-  bool operator==(const Cell& other) const {
-    return (parent_coordinate == other.parent_coordinate);
-  }
-};
-
-struct MotionConstraint {
-  std::vector<int> dx;
-  std::vector<int> dy;
-  size_t size() const { return dx.size(); }
-};
 
 /*
 y
@@ -58,6 +34,15 @@ y
 
 class Dijikstra {
  public:
+  struct Cell {
+    Coordinate parent_coordinate;
+    float cost{std::numeric_limits<float>::max()};
+    bool occupied{false};
+    bool operator==(const Cell& other) const {
+      return (parent_coordinate == other.parent_coordinate);
+    }
+  };
+
   explicit Dijikstra(const struct MotionConstraint& motion_constraint);
   ~Dijikstra() = default;
 

--- a/include/algorithm/robotics/shared_type/data_type.hpp
+++ b/include/algorithm/robotics/shared_type/data_type.hpp
@@ -1,0 +1,26 @@
+/*
+ * data_type.hpp
+ *
+ * Created on: Sep 27, 2022 20:59
+ * Description:
+ *
+ * Copyright (c) 2022 Pin Loon Lee (pllee4)
+ */
+
+#ifndef DATA_TYPE_HPP
+#define DATA_TYPE_HPP
+
+namespace pllee4::graph {
+/**
+ * @brief Coordinate in int
+ *
+ */
+struct Coordinate {
+  int x;
+  int y;
+  bool operator==(const Coordinate &other) const {
+    return (x == other.x && y == other.y);
+  }
+};
+}  // namespace pllee4::graph
+#endif /* DATA_TYPE_HPP */

--- a/include/algorithm/robotics/shared_type/motion_constraint.hpp
+++ b/include/algorithm/robotics/shared_type/motion_constraint.hpp
@@ -1,0 +1,25 @@
+/*
+ * motion_constraint.hpp
+ *
+ * Created on: Sep 27, 2022 21:11
+ * Description:
+ *
+ * Copyright (c) 2022 Pin Loon Lee (pllee4)
+ */
+
+#ifndef MOTION_CONSTRAINT_HPP
+#define MOTION_CONSTRAINT_HPP
+
+namespace pllee4::graph {
+/**
+ * @brief MotionConstraint for x and y
+ *
+ */
+struct MotionConstraint {
+  std::vector<int> dx;
+  std::vector<int> dy;
+  size_t size() const { return dx.size(); }
+};
+}  // namespace pllee4::graph
+
+#endif /* MOTION_CONSTRAINT_HPP */

--- a/src/robotics/CMakeLists.txt
+++ b/src/robotics/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(astar)
 add_subdirectory(dijikstra)
+add_subdirectory(shared_type)

--- a/src/robotics/astar/CMakeLists.txt
+++ b/src/robotics/astar/CMakeLists.txt
@@ -1,5 +1,6 @@
 # Astar as library target
 add_library(astar STATIC src/astar.cpp)
+target_link_libraries(astar INTERFACE shared_type)
 target_include_directories(astar PUBLIC
 $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 

--- a/src/robotics/dijikstra/CMakeLists.txt
+++ b/src/robotics/dijikstra/CMakeLists.txt
@@ -1,5 +1,6 @@
 # dijikstra as library target
 add_library(dijikstra STATIC src/dijikstra.cpp)
+target_link_libraries(dijikstra INTERFACE shared_type)
 target_include_directories(dijikstra PUBLIC
 $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)
 

--- a/src/robotics/shared_type/CMakeLists.txt
+++ b/src/robotics/shared_type/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(shared_type INTERFACE)
+target_include_directories(shared_type INTERFACE
+$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>)


### PR DESCRIPTION
- Moved common part in robotics to shared_type
- This shall prevent compilation warning when both astar.hpp and dijikstra.hpp are included
- Will bump new version of package after this PR